### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -181,6 +181,8 @@ jobs:
     name: Release to PyPI
     needs: [python-build, web-build]
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
     
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/ismailtsdln/GhidraInsight/security/code-scanning/4](https://github.com/ismailtsdln/GhidraInsight/security/code-scanning/4)

In general, the problem is fixed by explicitly specifying least‑privilege `permissions` for the `GITHUB_TOKEN` either at the workflow root (affecting all jobs) or per job. Since `docker-build` already has a tailored `permissions` block and we should not change its behavior, the safest change is to add an explicit minimal `permissions` block to the `release` job only.

Concretely, in `.github/workflows/ci-cd.yml`, under the `release` job (around line 179), add a `permissions:` section with `contents: read`. This gives the `release` job only read access to repository contents, which is sufficient for checking out the code and building the distribution, while avoiding any write privileges. No imports or additional methods are needed; this is purely a YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
